### PR TITLE
feat: update mermaid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,10 +6,10 @@
   "packages": {
     "": {
       "name": "mermaid",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "license": "MIT",
       "dependencies": {
-        "mermaid": "8.13.10"
+        "mermaid": "9.1.1"
       },
       "devDependencies": {
         "@babel/eslint-parser": "^7.16.3",
@@ -1701,9 +1701,9 @@
       }
     },
     "node_modules/@braintree/sanitize-url": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-3.1.0.tgz",
-      "integrity": "sha512-GcIY79elgB+azP74j8vqkiXz8xLFfIzbQJdlwOPisgbKT00tviJQuEghOXSMVxJ00HoYJbGswr4kcllUc4xCcg=="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-6.0.0.tgz",
+      "integrity": "sha512-mgmE7XBYY/21erpzhexk4Cj1cyTQ9LzvnTxtzM17BJ7ERMNE6W72mQRo0I1Ud8eFJ+RVVIcBNhLFZ3GX4XFz5w=="
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.0.5",
@@ -2437,9 +2437,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.3.4.tgz",
-      "integrity": "sha512-6BVcgOAVFXjI0JTjEvZy901Rghm+7fDQOrNIcxB4+gdhj6Kwp6T9VBhBY/AbagKHJocRkDYGd6wvI+p4/10xtQ=="
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.3.6.tgz",
+      "integrity": "sha512-OFP2u/3T1R5CEgWCEONuJ1a5+MFKnOYpkywpUSxv/dj1LeBT1erK+JwM7zK0ROy2BRhqVCf0LRw/kHqKuMkVGg=="
     },
     "node_modules/electron-to-chromium": {
       "version": "1.4.57",
@@ -3422,9 +3422,9 @@
       }
     },
     "node_modules/khroma": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/khroma/-/khroma-1.4.1.tgz",
-      "integrity": "sha512-+GmxKvmiRuCcUYDgR7g5Ngo0JEDeOsGdNONdU2zsiBQaK4z19Y2NvXqfEDE0ZiIrg45GTZyAnPLVsLZZACYm3Q=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.0.0.tgz",
+      "integrity": "sha512-2J8rDNlQWbtiNYThZRvmMv5yt44ZakX+Tz5ZIp/mN1pt4snn+m030Va5Z4v8xA0cQFDXBwO/8i42xL4QPsVk3g=="
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -3469,17 +3469,17 @@
       }
     },
     "node_modules/mermaid": {
-      "version": "8.13.10",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-8.13.10.tgz",
-      "integrity": "sha512-2ANep359uML87+wiYaWSu83eg9Qc0xCLnNJdCh100m4v0orS3fp8SScsZLcDSElRGHi+1zuVJsEEVEWH05+COQ==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-9.1.1.tgz",
+      "integrity": "sha512-2RVD+WkzZ4VDyO9gQvQAuQ/ux2gLigJtKDTlbwjYqOR/NwsVzTSfGm/kx648/qWJsg6Sv04tE9BWCO8s6a+pFA==",
       "dependencies": {
-        "@braintree/sanitize-url": "^3.1.0",
+        "@braintree/sanitize-url": "^6.0.0",
         "d3": "^7.0.0",
         "dagre": "^0.8.5",
         "dagre-d3": "^0.6.4",
-        "dompurify": "2.3.4",
+        "dompurify": "2.3.6",
         "graphlib": "^2.1.8",
-        "khroma": "^1.4.1",
+        "khroma": "^2.0.0",
         "moment-mini": "^2.24.0",
         "stylis": "^4.0.10"
       }
@@ -5760,9 +5760,9 @@
       }
     },
     "@braintree/sanitize-url": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-3.1.0.tgz",
-      "integrity": "sha512-GcIY79elgB+azP74j8vqkiXz8xLFfIzbQJdlwOPisgbKT00tviJQuEghOXSMVxJ00HoYJbGswr4kcllUc4xCcg=="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-6.0.0.tgz",
+      "integrity": "sha512-mgmE7XBYY/21erpzhexk4Cj1cyTQ9LzvnTxtzM17BJ7ERMNE6W72mQRo0I1Ud8eFJ+RVVIcBNhLFZ3GX4XFz5w=="
     },
     "@eslint/eslintrc": {
       "version": "1.0.5",
@@ -6385,9 +6385,9 @@
       }
     },
     "dompurify": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.3.4.tgz",
-      "integrity": "sha512-6BVcgOAVFXjI0JTjEvZy901Rghm+7fDQOrNIcxB4+gdhj6Kwp6T9VBhBY/AbagKHJocRkDYGd6wvI+p4/10xtQ=="
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.3.6.tgz",
+      "integrity": "sha512-OFP2u/3T1R5CEgWCEONuJ1a5+MFKnOYpkywpUSxv/dj1LeBT1erK+JwM7zK0ROy2BRhqVCf0LRw/kHqKuMkVGg=="
     },
     "electron-to-chromium": {
       "version": "1.4.57",
@@ -7103,9 +7103,9 @@
       }
     },
     "khroma": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/khroma/-/khroma-1.4.1.tgz",
-      "integrity": "sha512-+GmxKvmiRuCcUYDgR7g5Ngo0JEDeOsGdNONdU2zsiBQaK4z19Y2NvXqfEDE0ZiIrg45GTZyAnPLVsLZZACYm3Q=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.0.0.tgz",
+      "integrity": "sha512-2J8rDNlQWbtiNYThZRvmMv5yt44ZakX+Tz5ZIp/mN1pt4snn+m030Va5Z4v8xA0cQFDXBwO/8i42xL4QPsVk3g=="
     },
     "levn": {
       "version": "0.4.1",
@@ -7144,17 +7144,17 @@
       }
     },
     "mermaid": {
-      "version": "8.13.10",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-8.13.10.tgz",
-      "integrity": "sha512-2ANep359uML87+wiYaWSu83eg9Qc0xCLnNJdCh100m4v0orS3fp8SScsZLcDSElRGHi+1zuVJsEEVEWH05+COQ==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-9.1.1.tgz",
+      "integrity": "sha512-2RVD+WkzZ4VDyO9gQvQAuQ/ux2gLigJtKDTlbwjYqOR/NwsVzTSfGm/kx648/qWJsg6Sv04tE9BWCO8s6a+pFA==",
       "requires": {
-        "@braintree/sanitize-url": "^3.1.0",
+        "@braintree/sanitize-url": "^6.0.0",
         "d3": "^7.0.0",
         "dagre": "^0.8.5",
         "dagre-d3": "^0.6.4",
-        "dompurify": "2.3.4",
+        "dompurify": "2.3.6",
         "graphlib": "^2.1.8",
-        "khroma": "^1.4.1",
+        "khroma": "^2.0.0",
         "moment-mini": "^2.24.0",
         "stylis": "^4.0.10"
       },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "inkdrop": "^5.x"
   },
   "dependencies": {
-    "mermaid": "8.13.10"
+    "mermaid": "9.1.1"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.16.3",


### PR DESCRIPTION
Adds new features such as gitGraph! :)

In  Github Markdown:

```mermaid
gitGraph
  commit
  commit
  branch develop
  checkout develop
  commit
  commit
  branch feat/do-thing
  checkout feat/do-thing
  commit
  commit
  checkout develop
  merge feat/do-thing
  checkout main
  merge develop tag: "v1.0.0"
```

In Inkdrop:
![image](https://user-images.githubusercontent.com/551858/169583071-2160549d-ac6c-43e6-8dbb-cc855f2399a9.png)

---

Reason for major version update of Mermaid:
> Moving the gitGraph from experimental alpha status to a fully supported diagram type which handles theming and directives. The grammar has changed slightly from the alpha version, and no longer supports reset operations and some internal fast-forwarding has been removed for simplicity. Some few GitGraphs based on the alpha version might break with the update. This is the reason for the major version number update.

&mdash; https://github.com/mermaid-js/mermaid/releases/tag/9.0.0
 