### PR TITLE
chore(dev): refactor ESLint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,26 +1,23 @@
-import react from 'eslint-plugin-react'
-import path from 'node:path'
-import { fileURLToPath } from 'node:url'
-import js from '@eslint/js'
-import { FlatCompat } from '@eslint/eslintrc'
+import eslintJs from '@eslint/js'
+import eslintReact from 'eslint-plugin-react'
+import eslintPrettier from 'eslint-plugin-prettier/recommended'
+import globals from 'globals'
 
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = path.dirname(__filename)
-const compat = new FlatCompat({
-  baseDirectory: __dirname,
-  recommendedConfig: js.configs.recommended,
-  allConfig: js.configs.all
-})
-
+/** @type {import('eslint').Linter.Config[]} */
 export default [
-  ...compat.extends('plugin:react/recommended', 'prettier'),
+  eslintJs.configs.recommended,
+  eslintReact.configs.flat.recommended,
+  eslintReact.configs.flat['jsx-runtime'],
+  eslintPrettier,
   {
-    plugins: {
-      react
-    },
+    files: ['lib/**/*.js', 'lib/**/*.jsx'],
 
     languageOptions: {
-      globals: {}
+      ecmaVersion: 2022,
+      globals: {
+        ...globals.browser,
+        ...globals.commonjs
+      }
     },
 
     rules: {
@@ -45,4 +42,3 @@ export default [
     }
   }
 ]
-

--- a/package.json
+++ b/package.json
@@ -13,11 +13,12 @@
     "mermaid": "10.9.3"
   },
   "devDependencies": {
-    "@eslint/eslintrc": "^3.2.0",
     "@eslint/js": "^9.15.0",
     "eslint": "^9.15.0",
     "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-prettier": "^5.2.1",
     "eslint-plugin-react": "^7.37.2",
+    "globals": "^15.12.0",
     "prettier": "^3.3.3"
   }
 }


### PR DESCRIPTION
I’ve adjusted the Flat configuration for ESLint. The plugins "eslint-plugin-react" and "prettier" fully support the new ESLint configuration format, making the use of "@eslint/eslintrc" unnecessary. Additionally, I’ve added "globals" to prevent ESLint from complaining about "require" and specified the correct file paths for linting.