### PR TITLE
Fix bugs, type safety and architectural issues

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,7 +10,7 @@ export default eslintTs.config(
   eslintReact.configs.flat['jsx-runtime'],
   eslintPrettier,
   {
-    ignores: ['**/node_modules/*', '/lib/**/*.js'],
+    ignores: ['**/node_modules/**', '/lib/**'],
     settings: { react: { version: '18' } }
   }
 )

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mermaid",
   "description": "Lets you draw diagrams and flowcharts with Mermaid",
-  "main": "./lib/index",
+  "main": "./lib/index.cjs",
   "type": "module",
   "version": "2.9.0",
   "keywords": [
@@ -22,7 +22,7 @@
     "mermaid": "11.4.1",
     "@eslint/js": "^9.20.0",
     "@types/node": "^22.13.4",
-    "@types/react": "^19.0.8",
+    "@types/react": "^18.3.0",
     "eslint": "^9.20.1",
     "eslint-config-prettier": "^10.0.1",
     "eslint-plugin-prettier": "^5.2.3",

--- a/src/Mermaid.tsx
+++ b/src/Mermaid.tsx
@@ -1,15 +1,10 @@
 import React, { useContext, useMemo } from 'react'
 import { useConfig, useMermaidRendering } from './utils'
 
+let idCounter = Date.now()
+
 const Mermaid: React.FC<CodeComponentProps> = ({ children }) => {
-  const id = useMemo(
-    () =>
-      `mermaid-${Math.random()
-        .toString(36)
-        .replace(/[^a-z]+/g, '')
-        .substring(0, 5)}`,
-    []
-  )
+  const id = useMemo(() => `mermaid-${idCounter++}`, [])
 
   const code = useMemo(() => {
     if (typeof children === 'string') return children

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -3,8 +3,18 @@ interface Disposable {
 }
 
 declare namespace Inkdrop {
+  interface PluginConfigEntry {
+    title: string
+    type: 'string' | 'boolean' | 'integer' | 'number'
+    default?: unknown
+    description?: string
+    enum?: string[]
+    minimum?: number
+    maximum?: number
+  }
+
   interface Plugin {
-    config: Record<string, unknown>
+    config: Record<string, PluginConfigEntry>
     activate(): void
     deactivate(): void
   }
@@ -16,7 +26,7 @@ declare namespace Inkdrop {
       title?: string
       fenced?: boolean
       className?: string
-      children: string[]
+      children: string | string[]
     }
 
     interface RemarkCodeComponents {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,10 @@
-import { lazy } from 'react'
+import { lazy, Suspense, createElement } from 'react'
 import { markdownRenderer } from 'inkdrop'
 
-const Mermaid = lazy(() => import('./Mermaid'))
+const MermaidLazy = lazy(() => import('./Mermaid'))
+
+const Mermaid = (props: CodeComponentProps) =>
+  createElement(Suspense, { fallback: null }, createElement(MermaidLazy, props))
 
 export default {
   config: {
@@ -14,6 +17,7 @@ export default {
     theme: {
       title: 'Theme',
       type: 'string',
+      description: 'Mermaid diagram colour theme',
       default: 'forest',
       enum: ['forest', 'default', 'neutral', 'dark', 'base']
     },

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,11 +3,11 @@ import { useState, useEffect, useRef } from 'react'
 
 export const useConfig = () => {
   const [theme, setTheme] = useState<MermaidConfig['theme']>(
-    inkdrop.config.get('mermaid.theme') || 'default'
+    inkdrop.config.get('mermaid.theme') || 'forest'
   )
 
   const [autoScale, setAutoScale] = useState<boolean>(
-    inkdrop.config.get('mermaid.autoScale')
+    inkdrop.config.get('mermaid.autoScale') ?? true
   )
 
   useEffect(() => {
@@ -28,19 +28,43 @@ export const useConfig = () => {
   return { theme, autoScale }
 }
 
+let lastInitConfig = ''
+
+const ensureMermaidInitialized = (printMode: boolean) => {
+  const theme = printMode
+    ? 'default'
+    : inkdrop.config.get('mermaid.theme') || 'forest'
+  const themeCSS = inkdrop.config.get('mermaid.themeCSS') || ''
+  const themeVariablesRaw =
+    inkdrop.config.get<string>('mermaid.themeVariables') || '{}'
+
+  const configKey = `${theme}:${themeCSS}:${themeVariablesRaw}:${printMode}`
+  if (configKey === lastInitConfig) return
+
+  let themeVariables: Record<string, unknown>
+  try {
+    themeVariables = JSON.parse(themeVariablesRaw)
+  } catch {
+    throw new Error(
+      `Invalid JSON in 'Custom theme variables' setting: ${themeVariablesRaw}`
+    )
+  }
+
+  mermaid.initialize({
+    startOnLoad: false,
+    theme,
+    themeCSS,
+    themeVariables
+  })
+  lastInitConfig = configKey
+}
+
 const renderDiagram = async (
   id: string,
   code: string,
   printMode: boolean
 ): Promise<RenderResult> => {
-  mermaid.initialize({
-    startOnLoad: false,
-    theme: printMode ? 'default' : inkdrop.config.get('mermaid.theme'),
-    themeCSS: inkdrop.config.get('mermaid.themeCSS'),
-    themeVariables: JSON.parse(
-      inkdrop.config.get<string>('mermaid.themeVariables') || '{}'
-    )
-  })
+  ensureMermaidInitialized(printMode)
   try {
     return await mermaid.render(id, code)
   } catch (err) {
@@ -70,6 +94,8 @@ export const useMermaidRendering = (
       .then(({ svg, bindFunctions }) => {
         if (cancelled || !svg.length) return
 
+        // Security note: SVG is sanitised by Mermaid's DOMPurify layer.
+        // Keep Mermaid pinned to a known-safe version and audit updates.
         container.innerHTML = svg
         const diagram = container.querySelector<SVGSVGElement>(`#${id}`)
         if (!diagram) return
@@ -81,6 +107,7 @@ export const useMermaidRendering = (
       })
       .catch(err => {
         if (!cancelled) {
+          container.innerHTML = ''
           setError(err)
         }
       })

--- a/tsup.config.js
+++ b/tsup.config.js
@@ -10,7 +10,7 @@ export default defineConfig({
   sourcemap: true,
   clean: true,
   outExtension() {
-    return { js: '.js' }
+    return { js: '.cjs' }
   },
   treeshake: true,
   noExternal: ['mermaid']


### PR DESCRIPTION
## Summary

Comprehensive code quality pass addressing bugs, type safety gaps and architectural concerns identified through analysis against the inkdrop-developer docs and best practices.

### Bugs Fixed

- **ID generation** - Replaced weak `Math.random().toString(36).replace(...)` with a deterministic counter. The old approach could produce 1-character IDs (e.g., `Math.random()` = 0.5), risking DOM collisions when multiple diagrams are on the same page.
- **Theme fallback mismatch** - Changed the `useConfig` fallback from `'default'` to `'forest'` to match the config schema default, preventing a brief theme flash on load.
- **Stale SVG on error** - Added `container.innerHTML = ''` in the error handler so a failed re-render clears the previous diagram instead of showing it alongside the error message.

### Architectural Improvements

- **Suspense boundary** - Wrapped the `React.lazy()` component in its own `Suspense` boundary instead of relying on Inkdrop's renderer to provide one.
- **Mermaid init caching** - Extracted `ensureMermaidInitialized()` with config-keyed caching to avoid re-initialising Mermaid's global state on every render call, preventing race conditions with concurrent diagrams.
- **CJS/ESM ambiguity** - Changed build output to `.cjs` extension and updated `main` in package.json to `./lib/index.cjs`, making the CommonJS format explicit while keeping `"type": "module"` for the ESM config files.

### Type Safety

- **`children` type** - Updated `CodeComponentProps.children` from `string[]` to `string | string[]` to match runtime behaviour.
- **React types** - Pinned `@types/react` from `^19.0.8` to `^18.3.0` to match the actual React 18 runtime.
- **`autoScale` guard** - Added `?? true` fallback to prevent silent `undefined` to `false` coercion.
- **Plugin config type** - Replaced loose `Record<string, unknown>` with a proper `PluginConfigEntry` interface.

### Code Quality

- **themeVariables error UX** - Wrapped JSON parse in try-catch with a descriptive error message instead of raw `SyntaxError`.
- **ESLint ignore** - Fixed `node_modules` pattern from `*` (single level) to `**` (recursive), simplified lib ignore to cover `.cjs` and source maps.
- **Theme description** - Added missing `description` to the `theme` config entry.

## Test Plan

- [x] Verify diagrams render correctly with each built-in theme (forest, default, neutral, dark, base)
- [x] Verify multiple diagrams on the same page render without ID collisions
- [x] Verify print mode uses the 'default' theme
- [x] Verify invalid mermaid syntax shows error message with no stale SVG
- [x] Verify invalid JSON in theme variables shows a descriptive error
- [x] Verify auto-scale toggle works in both directions
- [x] Build with `npm run build` and confirm output is `lib/index.cjs`